### PR TITLE
Fix Android build: minapi bump + CI cache invalidation

### DIFF
--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -36,9 +36,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .buildozer
-          key: ${{ runner.os }}-buildozer-app
+          # Keyed on buildozer.spec's content, not a static string. p4a's
+          # per-target build directories (e.g. other_builds/python3/
+          # arm64-v8a__ndk_target_23) get reused verbatim from a restored
+          # cache even when android.minapi/android.api change, silently
+          # rebuilding against the OLD target — a static key masked the
+          # android.minapi 23->24 fix (still compiled against android23-clang
+          # after the bump). restore-keys still allows a same-spec run to
+          # partially reuse the previous cache; a spec change gets a full
+          # cache miss and a clean rebuild against the new settings.
+          key: ${{ runner.os }}-buildozer-app-${{ hashFiles('buildozer.spec') }}
           restore-keys: |
-            ${{ runner.os }}-buildozer-app
+            ${{ runner.os }}-buildozer-app-
 
       - name: Cache Android SDK
         uses: actions/cache@v4

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -109,7 +109,13 @@ android.presplash_color = 0xffffffff
 android.api = 34
 
 # (int) Minimum API your APK / AAB will support.
-android.minapi = 23
+# 24, not 23: CPython 3.13+'s Python/remote_debugging.c (PEP 768) calls
+# preadv()/pwritev(), which Android's bionic libc only declares starting at
+# API 24 (https://github.com/aosp-mirror/platform_bionic/blob/master/android-changes-for-ndk-developers.md).
+# At minapi=23, the p4a python3 recipe fails to compile with "call to
+# undeclared function 'preadv'" under modern strict Clang. API 23 is
+# Android 6.0 (2015) with negligible real-world share; this costs nothing.
+android.minapi = 24
 
 # (int) Android SDK version to use
 #android.sdk = 20


### PR DESCRIPTION
## Summary
The last build failed compiling CPython itself (not our code):

```
error: call to undeclared function 'preadv'
error: call to undeclared function 'pwritev'
```

in `Python/remote_debugging.c` (CPython 3.13+'s PEP 768 remote debugging support). Android's bionic libc only declares `preadv`/`pwritev` starting at **API 24** — `buildozer.spec` had `android.minapi = 23`.

- Bumped `android.minapi` 23 → 24 (Android 7.0, 2016 — negligible real-world device loss vs. 23)
- **Also found and fixed why the first attempt at this same fix didn't take effect on CI:** the "Cache Buildozer directory in app" step used a static cache key, so every run restored the same `.buildozer` directory (containing p4a's per-target build tree, e.g. `other_builds/python3/arm64-v8a__ndk_target_23/...`) regardless of `buildozer.spec` changes — the previous minapi bump silently kept compiling against `android23-clang`. Keyed the cache on `hashFiles('buildozer.spec')` instead, so a spec change now gets a clean rebuild.

## Test plan
- [x] 72 tests pass, all `.py` compile, all `.kv` parse
- [ ] Next CI run should be a full clean rebuild (cache miss due to the new hash-based key) — this is the actual test of whether minapi=24 resolves the compile error