### PR TITLE
Fix Android build (minapi + CI cache), update README for SQLite architecture

### DIFF
--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -36,9 +36,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .buildozer
-          key: ${{ runner.os }}-buildozer-app
+          # Keyed on buildozer.spec's content, not a static string. p4a's
+          # per-target build directories (e.g. other_builds/python3/
+          # arm64-v8a__ndk_target_23) get reused verbatim from a restored
+          # cache even when android.minapi/android.api change, silently
+          # rebuilding against the OLD target — a static key masked the
+          # android.minapi 23->24 fix (still compiled against android23-clang
+          # after the bump). restore-keys still allows a same-spec run to
+          # partially reuse the previous cache; a spec change gets a full
+          # cache miss and a clean rebuild against the new settings.
+          key: ${{ runner.os }}-buildozer-app-${{ hashFiles('buildozer.spec') }}
           restore-keys: |
-            ${{ runner.os }}-buildozer-app
+            ${{ runner.os }}-buildozer-app-
 
       - name: Cache Android SDK
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository contains an application designed to automate the process of plan
 
 ---
 
+## Stack
+
+`Python` · `Kivy` · `KivyMD` · `SQLite` · `kivy_garden.graph` · `Buildozer` · `pytest`
+
+---
+
 ### Why did I build this project?
 
 I wanted to understand the process of developing a full-featured application in `Python` and launching it on a mobile device.
@@ -43,6 +49,17 @@ The app implements **3 types of progressive overload**:
 - **kivymd 2.0.1.dev0**
 - **kivy-garden 0.1.5**
 - **kivy-garden-graph 0.4.1.dev0**
+- **sqlite3** (Python standard library) — ground-truth storage, see [Data layer](#data-layer) below
+
+---
+
+### Data layer
+
+App data (programs, exercises, workout history, progression targets) lives in a normalized **SQLite** database, not a JSON blob — `programs`, `exercises`, `workout_sessions`, `session_exercises`, and `sets` tables, plus an `app_meta` key/value table for settings and schema versioning. A repository layer (`ProgramRepository`, `WorkoutRepository`, `SettingsRepository`) owns all reads and writes, sharing a single connection; the service layer never touches SQL directly.
+
+On first launch after an upgrade from an older version, a one-time transactional migration imports the legacy `app_data.json` into the database and renames it to `app_data.json.bak` — safe to interrupt: if the app is killed mid-migration, the next launch retries cleanly instead of leaving partial data.
+
+This move away from a single JSON file was specifically to make the data queryable — the normalized schema is what future ML-driven features (progression trend analysis, plateau detection) will read from directly with SQL, instead of deserializing and looping over the whole history in Python.
 
 ---
 
@@ -62,8 +79,12 @@ workout_tracking_app/
 │   └── main_screen.kv --> organizing navigation across different app screens
 ├── logic/
 │   ├── components.py --> some UI components
-│   ├── storage.py --> reading/writing JSON, app data container
-│   ├── models.py --> typed models and helpers
+│   ├── schema.py --> SQLite schema (tables, indexes, schema_version)
+│   ├── database.py --> connection bootstrap: creates schema, runs migration
+│   ├── migration.py --> one-time transactional import from legacy app_data.json
+│   ├── repositories.py --> ProgramRepository, WorkoutRepository, SettingsRepository — all SQL lives here
+│   ├── dataclasses.py --> typed Program/Exercise/WorkoutSession/... records returned by the repositories
+│   ├── errors.py --> StorageWriteError + rollback-on-failure wrapper for writes
 │   ├── progression.py
 │   ├── services.py --> CRUD for program/exercise, saving/summary of workouts, history, charts
 │   ├── session_state.py
@@ -77,8 +98,10 @@ workout_tracking_app/
 │   ├── progressive_overload_screen.py
 │   ├── workout_screen.py
 │   └── main_screen.py --> organizing navigation across different app screens
+├── tests/ --> pytest suite: repository CRUD, migration, progression logic, error handling
 ├──   __init__.py
 ├──   main.py --> main file, launches the app
+├──   buildozer.spec --> Android packaging config
 ├──   .gitignore
 ├──   README.md
 └──   requirements.txt
@@ -123,4 +146,10 @@ To set up the project environment, follow these steps:
 
 ```bash
 python main.py
+```
+
+2. Run the test suite:
+
+```bash
+python -m pytest tests/
 ```

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -109,7 +109,13 @@ android.presplash_color = 0xffffffff
 android.api = 34
 
 # (int) Minimum API your APK / AAB will support.
-android.minapi = 23
+# 24, not 23: CPython 3.13+'s Python/remote_debugging.c (PEP 768) calls
+# preadv()/pwritev(), which Android's bionic libc only declares starting at
+# API 24 (https://github.com/aosp-mirror/platform_bionic/blob/master/android-changes-for-ndk-developers.md).
+# At minapi=23, the p4a python3 recipe fails to compile with "call to
+# undeclared function 'preadv'" under modern strict Clang. API 23 is
+# Android 6.0 (2015) with negligible real-world share; this costs nothing.
+android.minapi = 24
 
 # (int) Android SDK version to use
 #android.sdk = 20


### PR DESCRIPTION
## Summary
- Bumped `android.minapi` 23 → 24: CI was failing compiling CPython itself (`error: call to undeclared function 'preadv'/'pwritev'` in `Python/remote_debugging.c`, CPython 3.13+'s PEP 768 support) — Android's bionic libc only declares those syscalls starting at API 24
- Fixed why that fix didn't take effect on the first attempt: the CI cache for `.buildozer` used a static key, silently reusing a stale per-target build tree across spec changes. Keyed it on `hashFiles('buildozer.spec')` instead
- Updated README: Project Structure and Dependencies still described the old JSON storage layer (`storage.py`/`models.py`, both deleted); added a Data layer section covering the SQLite schema/repository pattern/migration, a Stack section, and a note on running the test suite

## Test plan
- [x] 72 tests pass, all `.py` compile, all `.kv` parse
- [ ] Next CI run should be a full clean rebuild (cache miss) targeting API 24 — this is the actual test of whether the compile error is resolved