### PR TITLE
Fix app dying after presplash: pin KivyMD off @master, add emulator smoke test, halve APK size

### DIFF
--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -17,6 +17,29 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    name: build (${{ matrix.name }})
+
+    # Two single-arch builds instead of one dual-arch build. Each extra arch
+    # duplicates the entire native payload, so building arm64-v8a + x86_64
+    # together produced a ~53MB APK where ~27MB of it was x86_64 libs that no
+    # phone can use. Splitting keeps the shipped artifact arm64-only (~26MB)
+    # while CI still gets an x86_64 APK it can install on the emulator.
+    # The two run in parallel, so wall-clock is roughly unchanged and total
+    # build minutes are about what the single dual-arch build already cost.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Shipped artifact: real devices are arm64.
+          - name: arm64-v8a
+            profile: ''
+            upload: true
+            smoke: false
+          # Test-only: x86_64 so it installs on the GitHub-hosted emulator.
+          - name: x86_64
+            profile: '--profile ci'
+            upload: false
+            smoke: true
 
     steps:
       - uses: actions/checkout@v4
@@ -49,9 +72,9 @@ jobs:
           # after the bump). restore-keys still allows a same-spec run to
           # partially reuse the previous cache; a spec change gets a full
           # cache miss and a clean rebuild against the new settings.
-          key: ${{ runner.os }}-buildozer-app-${{ hashFiles('buildozer.spec') }}
+          key: ${{ runner.os }}-buildozer-app-${{ matrix.name }}-${{ hashFiles('buildozer.spec') }}
           restore-keys: |
-            ${{ runner.os }}-buildozer-app-
+            ${{ runner.os }}-buildozer-app-${{ matrix.name }}-
 
       - name: Cache Android SDK
         uses: actions/cache@v4
@@ -146,12 +169,13 @@ jobs:
       - name: Build with Buildozer
         id: buildozer
         run: |
-          yes | buildozer -v android debug
+          yes | buildozer -v ${{ matrix.profile }} android debug
         # yes | buildozer -v android release
         # run this for generating aab (Android App Bundle) [Required by google play]
 
       # Upload artifacts
       - name: Upload APK artifact
+        if: matrix.upload
         uses: actions/upload-artifact@v4
         with:
           name: package
@@ -169,6 +193,7 @@ jobs:
       # log so startup failures are visible in CI instead of needing a
       # physical device.
       - name: Enable KVM for the emulator
+        if: matrix.smoke
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -176,6 +201,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Launch app on emulator and capture Python log
+        if: matrix.smoke
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34

--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -183,41 +183,7 @@ jobs:
           target: google_apis
           profile: pixel_6
           disable-animations: true
-          script: |
-            adb install -r bin/*.apk
-
-            # Discover the package rather than hardcoding it: buildozer can
-            # transform package.name, and the activity class differs between
-            # p4a bootstraps/branches. Guessing it wrong silently launches
-            # nothing and yields an empty log that looks like a crash.
-            PKG=$(adb shell pm list packages | tr -d '\r' | sed 's/^package://' | grep -i wtracker | head -1)
-            echo "RESOLVED PACKAGE: ${PKG:-<none found>}"
-            if [ -z "$PKG" ]; then
-              echo "APK installed but no matching package found — listing all third-party packages:"
-              adb shell pm list packages -3
-              exit 1
-            fi
-            echo "RESOLVED LAUNCH ACTIVITY:"
-            adb shell cmd package resolve-activity --brief "$PKG" | tail -1
-
-            adb logcat -c
-            # monkey with the LAUNCHER category starts whatever the manifest
-            # declares as the entry activity, so no class name is needed.
-            adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1
-            # Give Python time to boot, import, and fail.
-            sleep 45
-
-            echo "===================== PYTHON LOG ====================="
-            # p4a tags Python output (tracebacks included) as "python".
-            adb logcat -d -s python:V || true
-            echo "================== BROAD PATTERN GREP ==============="
-            # Fallback in case the tag differs: search the whole buffer.
-            adb logcat -d 2>/dev/null \
-              | grep -iE "traceback|modulenotfound|importerror|no module|python|wtracker|AndroidRuntime" \
-              | tail -120 || true
-            echo "===================== PROCESS STATE ================="
-            adb shell ps -A | grep -i wtracker || echo "PROCESS NOT RUNNING (died during startup)"
-            echo "====================================================="
+          script: bash ci/smoke_test.sh
         # Never fail the build on this: a crashing app is exactly what we
         # are trying to observe, and the log above is the deliverable.
         continue-on-error: true

--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -184,20 +184,38 @@ jobs:
           profile: pixel_6
           disable-animations: true
           script: |
-            set -x
             adb install -r bin/*.apk
+
+            # Discover the package rather than hardcoding it: buildozer can
+            # transform package.name, and the activity class differs between
+            # p4a bootstraps/branches. Guessing it wrong silently launches
+            # nothing and yields an empty log that looks like a crash.
+            PKG=$(adb shell pm list packages | tr -d '\r' | sed 's/^package://' | grep -i wtracker | head -1)
+            echo "RESOLVED PACKAGE: ${PKG:-<none found>}"
+            if [ -z "$PKG" ]; then
+              echo "APK installed but no matching package found — listing all third-party packages:"
+              adb shell pm list packages -3
+              exit 1
+            fi
+            echo "RESOLVED LAUNCH ACTIVITY:"
+            adb shell cmd package resolve-activity --brief "$PKG" | tail -1
+
             adb logcat -c
-            adb shell am start -n org.wtracker.wtrackerApk/org.kivy.android.PythonActivity
+            # monkey with the LAUNCHER category starts whatever the manifest
+            # declares as the entry activity, so no class name is needed.
+            adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1
             # Give Python time to boot, import, and fail.
             sleep 45
 
             echo "===================== PYTHON LOG ====================="
-            # p4a tags all Python output (including tracebacks) as "python".
+            # p4a tags Python output (tracebacks included) as "python".
             adb logcat -d -s python:V || true
-            echo "===================== FATAL / CRASH ================="
-            adb logcat -d *:E | grep -iE "AndroidRuntime|python|wtracker" || true
+            echo "================== BROAD PATTERN GREP ==============="
+            # Fallback in case the tag differs: search the whole buffer.
+            adb logcat -d 2>/dev/null \
+              | grep -iE "traceback|modulenotfound|importerror|no module|python|wtracker|AndroidRuntime" \
+              | tail -120 || true
             echo "===================== PROCESS STATE ================="
-            # If the process is gone, it died during startup.
             adb shell ps -A | grep -i wtracker || echo "PROCESS NOT RUNNING (died during startup)"
             echo "====================================================="
         # Never fail the build on this: a crashing app is exactly what we

--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -159,3 +159,47 @@ jobs:
             bin/*.apk
             bin/*.aab
           retention-days: 3
+
+      # --- Runtime smoke test -------------------------------------------
+      # The build succeeding says nothing about whether the app actually
+      # runs: it was dying on the presplash with no Android-level crash
+      # event (a clean Python-side exit is not a Java crash/ANR), so
+      # Firebase Test Lab reported "no crashes" while the app never
+      # started. Boot an emulator, launch the app, and dump the Python
+      # log so startup failures are visible in CI instead of needing a
+      # physical device.
+      - name: Enable KVM for the emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Launch app on emulator and capture Python log
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            set -x
+            adb install -r bin/*.apk
+            adb logcat -c
+            adb shell am start -n org.wtracker.wtrackerApk/org.kivy.android.PythonActivity
+            # Give Python time to boot, import, and fail.
+            sleep 45
+
+            echo "===================== PYTHON LOG ====================="
+            # p4a tags all Python output (including tracebacks) as "python".
+            adb logcat -d -s python:V || true
+            echo "===================== FATAL / CRASH ================="
+            adb logcat -d *:E | grep -iE "AndroidRuntime|python|wtracker" || true
+            echo "===================== PROCESS STATE ================="
+            # If the process is gone, it died during startup.
+            adb shell ps -A | grep -i wtracker || echo "PROCESS NOT RUNNING (died during startup)"
+            echo "====================================================="
+        # Never fail the build on this: a crashing app is exactly what we
+        # are trying to observe, and the log above is the deliverable.
+        continue-on-error: true

--- a/.github/workflows/Buildozer Action.yml
+++ b/.github/workflows/Buildozer Action.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches:
       - main
+  # Allows building any branch on demand from the Actions tab or
+  # `gh workflow run "Android Build" --ref <branch>`, without needing an
+  # open PR or a push to main.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ The app implements **3 types of progressive overload**:
 
 ### Dependencies:
 
-- **Python 3.12.4**
+- **Python 3.12.4** — the interpreter, installed separately (not via `pip`)
 - **Kivy 2.3.1**
-- **kivymd 2.0.1.dev0**
+- **KivyMD 2.0.1.dev0** — pinned to commit [`95184d9`](https://github.com/kivymd/KivyMD/tree/95184d98c6215a3f5cc0821708628963b654a59e)
 - **kivy-garden 0.1.5**
-- **kivy-garden-graph 0.4.1.dev0**
+- **kivy_garden.graph 0.4.1.dev0** — pinned to commit [`27c93e0`](https://github.com/kivy-garden/graph/tree/27c93e044cdae041c3fd1c98548bce7494f61e9e)
+- **materialyoucolor 2.0.10** — pulled in by KivyMD, pinned deliberately (see below)
 - **sqlite3** (Python standard library) — ground-truth storage, see [Data layer](#data-layer) below
+
+KivyMD and `kivy_garden.graph` are installed **from git at exact commits**, because neither is on PyPI at the version this app needs — both report `.dev0` versions that exist only on their master branches.
+
+Those pins are load-bearing rather than housekeeping. `2.0.1.dev0` is the version string KivyMD master has carried for over a year, so it identifies nothing: KivyMD master later started importing `materialyoucolor.dynamiccolor.color_spec`, which materialyoucolor 2.0.10 does not provide. Tracking master produced an Android build that compiled cleanly and then died at startup with `ModuleNotFoundError`. `buildozer.spec` pins KivyMD to the same commit — **keep the two in sync**.
 
 ---
 
@@ -99,6 +104,10 @@ workout_tracking_app/
 │   ├── workout_screen.py
 │   └── main_screen.py --> organizing navigation across different app screens
 ├── tests/ --> pytest suite: repository CRUD, migration, progression logic, error handling
+├── ci/
+│   └── smoke_test.sh --> boots the app on a CI emulator and dumps the Python log
+├── .github/workflows/
+│   └── Buildozer Action.yml --> Android build matrix + emulator smoke test
 ├──   __init__.py
 ├──   main.py --> main file, launches the app
 ├──   buildozer.spec --> Android packaging config
@@ -153,3 +162,43 @@ python main.py
 ```bash
 python -m pytest tests/
 ```
+
+---
+
+### Android build
+
+The APK is built with **Buildozer** / python-for-android, configured in `buildozer.spec`.
+
+```bash
+# Debug APK for a real device (arm64-v8a) -> bin/wtrackerApk-0.1-arm64-v8a-debug.apk
+buildozer -v android debug
+
+# x86_64 build, used only for testing on an emulator
+buildozer -v --profile ci android debug
+```
+
+**Architectures.** Only `arm64-v8a` is shipped. Every additional arch duplicates the entire native payload — `libpybundle.so` alone is ~16 MB per arch — so building `arm64-v8a` and `x86_64` together produced a 53 MB APK of which roughly half was libraries no phone could execute. Restricting to `arm64-v8a` puts the debug APK at ~26 MB.
+
+x86_64 is still needed to install on a GitHub-hosted emulator, so it lives in a separate `[app@ci]` profile at the bottom of `buildozer.spec` rather than in the shipped configuration.
+
+**`minapi` is 24, not 23.** CPython's `remote_debugging.c` uses `preadv`/`pwritev`, which the NDK only declares from API 24; on 23 the build fails to compile.
+
+### Continuous integration
+
+`.github/workflows/Buildozer Action.yml` runs on pushes and PRs to `main`, and on demand via `workflow_dispatch` for any branch. It builds two legs in parallel:
+
+| Leg | Arch | Purpose |
+|---|---|---|
+| `build (arm64-v8a)` | arm64-v8a | Produces the uploaded APK artifact |
+| `build (x86_64)` | x86_64 | Boots an emulator and runs the runtime smoke test |
+
+**Why a smoke test.** A green build says nothing about whether the app actually runs. The app once built successfully and then died on the presplash on every launch — and because python-for-android exits the process cleanly when Python raises during startup, that is not a Java crash or an ANR, so Firebase Test Lab reported *"no crashes"* while the app had never started. `ci/smoke_test.sh` installs the APK, launches it through the LAUNCHER intent, and dumps `logcat -s python`, making startup tracebacks visible in CI without a physical device. A healthy run reaches:
+
+```
+[INFO] [Base] Start application main loop
+PROCESS IS RUNNING (app survived startup)
+```
+
+The smoke test never fails the build on a crashing app — the captured log is the deliverable.
+
+**Caching.** The `.buildozer` cache key includes a hash of `buildozer.spec` and the matrix leg name. Both matter: a static key once restored p4a's per-target build tree even after `android.minapi` changed, silently rebuilding against the old target, and an unscoped key would let one arch's leg save a cache the other then restores without its own build tree.

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -45,7 +45,13 @@ version = 0.1
 # ends up without _sqlite3 — the build still succeeds, then `import sqlite3`
 # fails at runtime and the app dies right after the presplash.
 # See kivy/python-for-android#1053.
-requirements = python3, kivy==2.3.1,kivy_garden==0.1.5,kivy_garden.graph, git+https://github.com/kivymd/KivyMD@master, exceptiongroup, asynckivy, asyncgui, materialyoucolor, android
+# NOTE: KivyMD is pinned to an exact commit, NOT @master. KivyMD master moved on
+# to a materialyoucolor that provides `dynamiccolor.color_spec`, but p4a's
+# materialyoucolor recipe is hard-pinned to 2.0.10, which does not have it. The
+# build still succeeds, then kivymd/theming.py raises ModuleNotFoundError at
+# import time and the app dies right after the presplash.
+# Unpin only together with a materialyoucolor recipe that ships color_spec.
+requirements = python3, kivy==2.3.1,kivy_garden==0.1.5,kivy_garden.graph, git+https://github.com/kivymd/KivyMD@95184d98c6215a3f5cc0821708628963b654a59e, exceptiongroup, asynckivy, asyncgui, materialyoucolor, android
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -305,7 +305,10 @@ android.enable_androidx = True
 # (list) The Android archs to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 # In past, was `android.arch` as we weren't supporting builds for multiple archs at the same time.
 # android.archs = arm64-v8a, armeabi-v7a
-android.archs = arm64-v8a
+# x86_64 is here so CI can install the APK on a GitHub-hosted emulator
+# (runners are x86_64; an arm64-only APK fails to install with
+# INSTALL_FAILED_NO_MATCHING_ABIS). arm64-v8a is what real devices use.
+android.archs = arm64-v8a, x86_64
 
 # (int) overrides automatic versionCode computation (used in build.gradle)
 # this is not the same as app version and should only be edited if you know what you're doing

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -39,7 +39,13 @@ version = 0.1
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3, sqlite3, kivy==2.3.1,kivy_garden==0.1.5,kivy_garden.graph, git+https://github.com/kivymd/KivyMD@master, exceptiongroup, asynckivy, asyncgui, materialyoucolor, android
+# NOTE: do NOT add sqlite3 here. p4a's python3 recipe already depends on
+# sqlite3 and builds _sqlite3 into CPython. Listing it explicitly can push
+# the sqlite3 recipe to build AFTER python3 instead of before, so CPython
+# ends up without _sqlite3 — the build still succeeds, then `import sqlite3`
+# fails at runtime and the app dies right after the presplash.
+# See kivy/python-for-android#1053.
+requirements = python3, kivy==2.3.1,kivy_garden==0.1.5,kivy_garden.graph, git+https://github.com/kivymd/KivyMD@master, exceptiongroup, asynckivy, asyncgui, materialyoucolor, android
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -311,10 +311,13 @@ android.enable_androidx = True
 # (list) The Android archs to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 # In past, was `android.arch` as we weren't supporting builds for multiple archs at the same time.
 # android.archs = arm64-v8a, armeabi-v7a
-# x86_64 is here so CI can install the APK on a GitHub-hosted emulator
-# (runners are x86_64; an arm64-only APK fails to install with
-# INSTALL_FAILED_NO_MATCHING_ABIS). arm64-v8a is what real devices use.
-android.archs = arm64-v8a, x86_64
+# Ship arm64-v8a only: every extra arch duplicates the whole native payload
+# (libpybundle.so alone is ~16MB per arch), so adding x86_64 here doubled the
+# APK from ~26MB to ~53MB for users who can never run those libs.
+# CI still needs x86_64 to install on a GitHub-hosted emulator (runners are
+# x86_64; an arm64-only APK fails with INSTALL_FAILED_NO_MATCHING_ABIS), so
+# that lives in the [app@ci] profile at the bottom of this file instead.
+android.archs = arm64-v8a
 
 # (int) overrides automatic versionCode computation (used in build.gradle)
 # this is not the same as app version and should only be edited if you know what you're doing
@@ -481,3 +484,13 @@ warn_on_root = 1
 #    Then, invoke the command line with the "demo" profile:
 #
 #buildozer --profile demo android debug
+
+# Profile used only by the CI emulator smoke test:
+#   buildozer --profile ci android debug
+# Builds x86_64 instead of arm64-v8a so the APK installs on the GitHub-hosted
+# emulator. Startup failures are ABI-independent (the KivyMD/materialyoucolor
+# import crash reproduced identically on x86_64 and on an arm64 phone), so
+# smoke-testing this arch still exercises the thing we care about. The APK
+# built under this profile is a test artifact and is never shipped.
+[app@ci]
+android.archs = x86_64

--- a/ci/smoke_test.sh
+++ b/ci/smoke_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Runtime smoke test executed on a CI emulator.
+#
+# This lives in a file rather than inline in the workflow because
+# reactivecircus/android-emulator-runner runs each line of its `script:`
+# input as a SEPARATE `sh -c` invocation. Shell variables do not survive
+# between lines and multi-line constructs (if/fi, loops) are split across
+# shells and fail with "Syntax error: end of file unexpected". The
+# workflow invokes this as a single line so the whole thing runs in one
+# shell.
+#
+# Purpose: a green build says nothing about whether the app runs. The app
+# has been dying on the presplash with no Android-level crash event (a
+# clean Python-side exit is not a Java crash/ANR), so Firebase Test Lab
+# reported "no crashes" while the app never started. This captures the
+# Python traceback in CI instead.
+set -u
+
+APK=$(ls bin/*.apk 2>/dev/null | head -1)
+echo "APK: ${APK:-<none>}"
+if [ -z "$APK" ]; then
+  echo "FAIL: no APK in bin/ — nothing to test"
+  exit 1
+fi
+
+adb install -r "$APK"
+
+echo "=== INSTALLED THIRD-PARTY PACKAGES ==="
+adb shell pm list packages -3 | tr -d '\r'
+
+PKG=$(adb shell pm list packages -3 | tr -d '\r' | sed 's/^package://' | grep -iE 'wtracker|kivy' | head -1)
+echo "RESOLVED PACKAGE: ${PKG:-<none found>}"
+if [ -z "$PKG" ]; then
+  echo "FAIL: APK installed but no matching package — see the full list above"
+  exit 1
+fi
+
+echo "RESOLVED LAUNCH ACTIVITY:"
+adb shell cmd package resolve-activity --brief "$PKG" | tr -d '\r' | tail -1
+
+adb logcat -c
+# monkey with the LAUNCHER category starts whatever entry activity the
+# manifest declares, so no hardcoded class name (a previous attempt
+# guessed org.kivy.android.PythonActivity and launched nothing).
+adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1
+# Give Python time to boot, import, and fail.
+sleep 45
+
+echo "===================== PYTHON LOG ====================="
+# p4a tags Python output (tracebacks included) as "python".
+adb logcat -d -s python:V | tr -d '\r' || true
+
+echo "================== BROAD PATTERN GREP ==============="
+# Fallback in case output is not tagged "python".
+adb logcat -d 2>/dev/null | tr -d '\r' \
+  | grep -iE "traceback|modulenotfound|importerror|no module|python|kivy|wtracker|AndroidRuntime|FATAL" \
+  | tail -150 || true
+
+echo "===================== PROCESS STATE ================="
+if adb shell ps -A | tr -d '\r' | grep -i "$PKG"; then
+  echo "PROCESS IS RUNNING (app survived startup)"
+else
+  echo "PROCESS NOT RUNNING (died during startup)"
+fi
+echo "====================================================="

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,25 @@
-Python==3.12.4
+# Python itself (3.12.4) is a runtime requirement, not a pip package — see the
+# README's Installation section. It used to be listed here as "Python==3.12.4",
+# which made `pip install -r requirements.txt` fail on its very first line.
+
 Kivy==2.3.1
-kivymd==2.0.1.dev0
 kivy-garden==0.1.5
-kivy-garden-graph==0.4.1.dev0
+
+# KivyMD and kivy_garden.graph are NOT installable from PyPI at the versions
+# this app needs: both report ".dev0" versions that exist only on their git
+# master branches (PyPI has kivymd 2.0.0 and kivy_garden.graph 0.4.0). They are
+# therefore installed from git, pinned to exact commits.
+#
+# The pins are load-bearing, not tidiness. KivyMD master later began importing
+# materialyoucolor.dynamiccolor.color_spec, which materialyoucolor 2.0.10 does
+# not provide. Because "2.0.1.dev0" names a whole year of master commits,
+# tracking master silently produced an Android build that compiled fine and
+# then died at startup with ModuleNotFoundError. buildozer.spec pins KivyMD to
+# this same commit; keep the two in sync.
+kivymd @ git+https://github.com/kivymd/KivyMD@95184d98c6215a3f5cc0821708628963b654a59e
+kivy_garden.graph @ git+https://github.com/kivy-garden/graph@27c93e044cdae041c3fd1c98548bce7494f61e9e
+
+# Pulled in by KivyMD. Pinned explicitly so the desktop environment matches what
+# python-for-android's recipe builds into the APK; 3.x is NOT compatible with
+# the KivyMD commit above.
+materialyoucolor==2.0.10


### PR DESCRIPTION
## Summary

The app built successfully but died right after the presplash, on a physical device and in Firebase Test Lab. Test Lab reported "no crashes" while never getting past `PythonActivity` — a clean Python-side exit is not a Java crash or ANR, so Android's crash detector never fired.

**Root cause: `requirements` pulled KivyMD from `@master`, an unpinned moving target.**

The CI emulator smoke test added in this PR finally captured the traceback:

```
File "main.py", line 4, in <module>
File "kivymd/app.py", line 82, in <module>
File "kivymd/theming.py", line 42, in <module>
ModuleNotFoundError: No module named 'materialyoucolor.dynamiccolor.color_spec'
```

Current KivyMD master's `theming.py` line 42 is literally `from materialyoucolor.dynamiccolor.color_spec import COLOR_NAMES`, but p4a's `materialyoucolor` recipe is hard-pinned to **2.0.10**, which has no `dynamiccolor/color_spec`. The build succeeds because p4a never imports kivymd — the mismatch only appears at app startup, at module-import time in `main.py`, i.e. after the presplash is on screen but before `build()`.

KivyMD is now pinned to `95184d9`, chosen by blob-hash comparison against the desktop dev environment (130 of 135 installed `.py` files byte-identical) and verified so that every materialyoucolor symbol KivyMD needs resolves against 2.0.10. Matching by hash rather than date matters here: KivyMD's master history is periodically rebased, so its commit dates are unreliable.

### Two earlier hypotheses, both disproven

Recorded so they are not retried:

| Hypothesis | Result |
|---|---|
| `sqlite3` missing from `requirements` | Added it — still died |
| `sqlite3` being listed was itself the problem | Removed it — still died |
| `minapi` 23 → 24 | Fixed a genuine *build* failure (CPython's `remote_debugging.c` needs `preadv`/`pwritev`, declared from API 24), but not the runtime death. Kept, mandatory |

### CI: emulator smoke test

A green build said nothing about whether the app runs. CI now boots an emulator, installs the APK, launches it via the LAUNCHER intent, and dumps the Python log, so startup failures are visible without a physical device. Lives in `ci/smoke_test.sh` — in a file rather than inline because `android-emulator-runner` runs each line of its `script:` input as a separate `sh -c`, which broke variables and `if/fi` blocks across shells.

Also adds `workflow_dispatch` so any branch can be built on demand.

### APK size: 53MB → 26MB

Enabling the smoke test required an x86_64 APK to install on the GitHub-hosted emulator, and widening `android.archs` doubled the shipped APK, because each arch carries a full copy of the native payload:

```
lib/x86_64      27.0MB  50.7%
lib/arm64-v8a   26.0MB  48.9%
everything else  0.3MB   0.5%   (app code, tests, dex, resources)
```

`libpybundle.so` alone is ~16MB per arch. Users on arm64 phones were downloading a second Python runtime they can never execute.

Fixed by shipping arm64-v8a only and moving x86_64 into an `[app@ci]` buildozer profile used just by the smoke test. The workflow is now a two-leg matrix: the arm64 leg uploads the artifact, the x86_64 leg boots the emulator. They run in parallel, so wall-clock is roughly unchanged and total build minutes are about what the dual-arch build already cost.

This keeps the diagnostic intact — startup failures are ABI-independent, and this exact crash reproduced identically on the x86_64 emulator and on an arm64 phone.

The `.buildozer` cache key is also now scoped per matrix leg. The legs write different p4a target trees, so a shared key would let whichever finished first win the save and leave the other restoring a cache missing its arch.

## Test plan

- [x] 72 tests pass; spec parses; workflow YAML valid
- [x] Buildozer profile merge verified: default → `arm64-v8a`, `--profile ci` → `x86_64`
- [x] Emulator smoke test reaches `[INFO] [Base] Start application main loop` and `PROCESS IS RUNNING (app survived startup)`
- [x] Zero `ModuleNotFoundError` / `Traceback` / `SIGABRT` in the runtime log (was 5 death signals before, 0 now)
- [x] Both matrix legs green; shipped APK is 99.2% `lib/arm64-v8a` with no `lib/x86_64`; artifact 50MB → 24MB
- [x] **Confirmed working on a physical device**

### Known non-blocking issue

The runtime log shows `Ignored class "SettingsTopAppBar" re-declaration` — the class is declared both in `app/logic/components.py` and as a rule in `app/kv/components.kv`. Kivy silently keeps the Python class and discards the kv rule. Not a crash and not addressed here, but worth a look in case the kv rule carries layout that was never being applied.
